### PR TITLE
Fix StartWithWindows for FBDashboard and FBuildWorker

### DIFF
--- a/Source/App.xaml.cs
+++ b/Source/App.xaml.cs
@@ -42,6 +42,8 @@ namespace FastBuild.Dashboard
 #endif
 		public bool StartMinimized { get; private set; }
 
+		public string LocationOverride { get; private set; }
+
 		public App()
 		{
 			this.InitializeComponent();
@@ -70,6 +72,10 @@ namespace FastBuild.Dashboard
 				if (startUp)
 				{
 					var location = entryAssembly.Location;
+					if (!string.IsNullOrEmpty(this.LocationOverride))
+					{
+						location = this.LocationOverride;
+					}
 					Debug.Assert(location != null, "location != null");
 					if (location.EndsWith(".shadow.exe", System.StringComparison.InvariantCultureIgnoreCase))
 					{
@@ -92,6 +98,14 @@ namespace FastBuild.Dashboard
 		public void ProcessArgs(string[] args)
 		{
 			this.StartMinimized = args.Contains("-minimized");
+
+			foreach (string argument in args)
+			{
+				if (argument.Contains("-parent="))
+				{
+					this.LocationOverride = argument.Substring("-parent=".Length, argument.Length - "-parent=".Length).Replace("\"", "");
+				}
+			}
 		}
 	}
 }

--- a/Source/AppBootstrapper.cs
+++ b/Source/AppBootstrapper.cs
@@ -39,8 +39,8 @@ namespace FastBuild.Dashboard
 
 		protected override void OnStartup(object sender, StartupEventArgs e)
 		{
-			App.Current.SetStartupWithWindows(AppSettings.Default.StartWithWindows);
 			App.Current.ProcessArgs(e.Args);
+			App.Current.SetStartupWithWindows(AppSettings.Default.StartWithWindows);
 
 #if DEBUG && !DEBUG_SINGLE_INSTANCE
 			this.DisplayRootViewFor<MainWindowViewModel>();
@@ -86,7 +86,7 @@ namespace FastBuild.Dashboard
 				Process.Start(new ProcessStartInfo
 				{
 					FileName = shadowPath,
-					Arguments = string.Join(" ", e.Args.Concat(new[] { "-no-shadow" }))
+					Arguments = string.Join(" ", e.Args.Concat(new[] { $"-no-shadow -parent=\"{assemblyLocation}\"" }))
 				});
 
 				Environment.Exit(0);

--- a/Source/AppBootstrapper.cs
+++ b/Source/AppBootstrapper.cs
@@ -61,7 +61,7 @@ namespace FastBuild.Dashboard
 			else
 			{
 				var shadowAssemblyName = $"{Path.GetFileNameWithoutExtension(assemblyLocation)}.shadow.exe";
-				var shadowPath = Path.Combine(Path.GetTempPath(), shadowAssemblyName);
+				var shadowPath = Path.Combine(Path.GetTempPath(), "FBDashboard", shadowAssemblyName);
 				try
 				{
 					if (File.Exists(shadowPath))
@@ -70,7 +70,21 @@ namespace FastBuild.Dashboard
 					}
 
 					Debug.Assert(assemblyLocation != null, "assemblyLocation != null");
+					Directory.CreateDirectory(Path.GetDirectoryName(shadowPath));
 					File.Copy(assemblyLocation, shadowPath);
+
+					// Copy FBuild folder with worker if exists.
+					var workerFolder = Path.Combine(Path.GetDirectoryName(assemblyLocation), "FBuild");
+					var workerTargetFolder = Path.Combine(Path.GetDirectoryName(shadowPath), "FBuild");
+					if (Directory.Exists(workerFolder))
+					{
+						Directory.CreateDirectory(workerTargetFolder);
+						// Copy all worker files.
+						foreach (string newPath in Directory.GetFiles(workerFolder, "*.*", SearchOption.TopDirectoryOnly))
+						{
+							File.Copy(newPath, newPath.Replace(workerFolder, workerTargetFolder), true);
+						}
+					}
 				}
 				catch (UnauthorizedAccessException)
 				{


### PR DESCRIPTION
After moving FBDashboard.shadow.exe to temp directory, it can't find original binary to setup path for windows startup.
I was trying to find how to remember path to original file, but I think only way is through cmd line parameter.

Second issue was that FBuildWorker.exe was search in working directory in "FBuild\FBuildWorker.exe" but when program is started from windows register, working directory is "c:\Windows\System32". So I added searching in relative path to running binary and copy FBuildWorker.exe also to temp directory. Moved both to subfolder "FBDashboard" in Temp directory.

Note: I'm not C# programmer so I'm sorry if I did something inappropriate.