### PR TITLE
Fix StartWithWindows for FBDashboard and FBuildWorker 

### DIFF
--- a/Source/App.xaml.cs
+++ b/Source/App.xaml.cs
@@ -81,6 +81,10 @@ namespace FastBuild.Dashboard
 				if (startUp)
 				{
 					var location = entryAssembly.Location;
+					if (this.ShadowContext != null && !string.IsNullOrEmpty(this.ShadowContext.OriginalLocation))
+					{
+						location = this.ShadowContext.OriginalLocation;
+					}
 					Debug.Assert(location != null, "location != null");
 
 					key.SetValue(entryAssembly.GetName().Name, $"\"{location}\" -minimized");

--- a/Source/AppBootstrapper.cs
+++ b/Source/AppBootstrapper.cs
@@ -79,7 +79,7 @@ namespace FastBuild.Dashboard
 		private static void SpawnShadowProcess(StartupEventArgs e, string assemblyLocation)
 		{
 			var shadowAssemblyName = $"{Path.GetFileNameWithoutExtension(assemblyLocation)}.shadow.exe";
-			var shadowPath = Path.Combine(Path.GetTempPath(), shadowAssemblyName);
+			var shadowPath = Path.Combine(Path.GetTempPath(), "FBDashboard", shadowAssemblyName);
 			try
 			{
 				if (File.Exists(shadowPath))
@@ -88,7 +88,21 @@ namespace FastBuild.Dashboard
 				}
 
 				Debug.Assert(assemblyLocation != null, "assemblyLocation != null");
+				Directory.CreateDirectory(Path.GetDirectoryName(shadowPath));
 				File.Copy(assemblyLocation, shadowPath);
+
+				// Copy FBuild folder with worker if exists.
+				var workerFolder = Path.Combine(Path.GetDirectoryName(assemblyLocation), "FBuild");
+				var workerTargetFolder = Path.Combine(Path.GetDirectoryName(shadowPath), "FBuild");
+				if (Directory.Exists(workerFolder))
+				{
+					Directory.CreateDirectory(workerTargetFolder);
+					// Copy all worker files.
+					foreach (string newPath in Directory.GetFiles(workerFolder, "*.*", SearchOption.TopDirectoryOnly))
+					{
+						File.Copy(newPath, newPath.Replace(workerFolder, workerTargetFolder), true);
+					}
+				}
 			}
 			catch (UnauthorizedAccessException)
 			{

--- a/Source/ShadowContext.cs
+++ b/Source/ShadowContext.cs
@@ -24,10 +24,12 @@ namespace FastBuild.Dashboard
 
 		
 		public string StorageDirectory { get; set; }
+		public string OriginalLocation { get; set; }
 
 		public ShadowContext()
 		{
 			this.StorageDirectory = SettingsBase.StorageDirectory;
+			this.OriginalLocation = Assembly.GetEntryAssembly().Location;
 		}
 
 		public void Save(string shadowPath)


### PR DESCRIPTION
Sorry to bother you about this again. Issue with StartWithWindows #9 still exists.

Save value between Original and Shadow binaries work nicely, but when you want to enable StartWithWindows in GUI it is done by shadow process, which only see it's path to temp.
I was thinking of best way to fix this and ShadowContext looks like perfect place for information from original to shadow binary.

Connected issue with FBuild not accessible for shadow process in Temp. There I can't find another way from last time and just copy FBuild to Shadow in Temp and try to find it there.

I hope this is not wasting your time, but I need this to work before giving this to co-workers.